### PR TITLE
add dynamic programming algorithm support

### DIFF
--- a/gym_jcr/jcr_env.py
+++ b/gym_jcr/jcr_env.py
@@ -81,4 +81,21 @@ class JacksCarRentalEnv(discrete.DiscreteEnv):
        
         super(JacksCarRentalEnv, self).__init__(nS, nA, P, isd)
 
+        # The following three elements enable this enviroment to be interfaced with
+        # the dynamic programming algorithms of the doctrina library:
+        # https://github.com/rhalbersma/doctrina/blob/master/src/doctrina/algorithms/dp.py
+        # https://github.com/rhalbersma/doctrina/blob/master/exercises/dp-gym_jcr.ipynb
+
+        # Equation (3.4) in Sutton & Barto (p.49):
+        # p(s'|s, a) = probability of transition to state s', from state s taking action a.
+        self.transition = Ptrans.transpose(1, 2, 0)
+        assert np.isclose(self.transition.sum(axis=2), 1).all()
+        
+        # Equation (3.5) in Sutton & Barto (p.49):
+        # r(s, a) = expected immediate reward from state s after action a.        
+        self.reward = R
+        
+        # The number of all states plus the terminal state, denoted |S+|.
+        # For a continuing task as Jack's Car Rental, this is the same as the number of all non-terminal states |S|. 
+        self.nSp = self.nS
 

--- a/gym_jcr/jcr_env.py
+++ b/gym_jcr/jcr_env.py
@@ -56,29 +56,21 @@ class JacksCarRentalEnv(discrete.DiscreteEnv):
         # can be MAX_CARS at each location A, B
         nS = (MAX_CARS + 1)**2
         
-        P = {s : {a : [] for a in range(nA)} for s in range(nS)}
-               
-        # prob, next_state, reward, done
-        for s in range(nS):
-            # need a state vec to extract correct probs from Ptrans
-            state_vec = np.zeros(nS)
-            state_vec[s] = 1
-            for a in range(nA):
-                prob_vec = np.dot(Ptrans[:,:,a], state_vec)
-                li = P[s][a]
-                # add rewards for all transitions
-                for ns in range(nS):
-                    li.append((prob_vec[ns], ns, R[s][a], False))
-
-        
         # obtain one-step dynamics for dynamic programming setting
-        self.P = P
-        
-        # isd initial state dist 
-        isd = np.ones(nS)/nS
-        
-        self.P = P
+        P = {
+            s: {
+                a: [
+                    (Ptrans[next, s, a], next, R[s, a], False)
+                    for next in range(nS)
+                ]
+                for a in range(nA)
+            }
+            for s in range(nS)
+        }
        
+        # isd initial state dist 
+        isd = np.full(nS, 1 / nS)
+              
         super(JacksCarRentalEnv, self).__init__(nS, nA, P, isd)
 
         # The following three elements enable this enviroment to be interfaced with


### PR DESCRIPTION
I added the already defined `Ptrans` and `R` matrices directly to the `jcr_env` environment as class members `transition` and `reward`, together with the number of nonterminal states `nSp` (equal to `nS` for this particular environment). 

This enables this environment to be interfaced with the NumPy based dynamic programming algorithms of my doctrina library. This will improve the runtime of policy iteration from ~30m to ~5s (and to ~1.3s for value iteration).

The changes to the environment in this PR correspond exactly to code block 2 in this notebook:
https://github.com/rhalbersma/doctrina/blob/master/exercises/dp-gym_jcr.ipynb

Furthermore, the initialization of the `P` dictionary has been sped up from ~15s to virtually instantenously. This new initialization does the following things differently:

- list comprehensions instead of `append` to an initially empty list
- directly indexing `Ptrans` with the `next` state, rather than via the `np.dot` of `state_vec` 
- directly using the indexed `Ptrans` vector rather than storing it in `prob_vec`
- direct indexing `R[s, a]` instead of the two-stage indexing `R[s][a]`
- no double assignment of `self.P` and `self.isd` (which were already being done by the call to the parent class constructor in `super`).
- using `np.full` instead of `np.one` for the initial uniformly random policy.

I have verified that this yields an identical dictionary.