### PR TITLE
strip Env suffix from registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ In your gym environment:
 
 ```python
 import gym_jcr
-env = gym.make("JacksCarRentalEnv-v0") 
+env = gym.make("JacksCarRental-v0") 
 ```
 

--- a/gym_jcr/__init__.py
+++ b/gym_jcr/__init__.py
@@ -1,12 +1,10 @@
 from gym.envs.registration import register
 
-from .jcr_env import JacksCarRentalEnv
+environments = [['JacksCarRental', 'v0']]
 
-environments = [['JacksCarRentalEnv', 'v0']]
-
-for environment in environments:
+for name, version in environments:
     register(
-        id='{}-{}'.format(environment[0], environment[1]),
-        entry_point='gym_jcr:{}'.format(environment[0]),
+        id=f'{name}-{version}',
+        entry_point=f'gym_jcr.jcr_env:{name}Env',
     )
 


### PR DESCRIPTION
This PR strips the Env suffix from the registry to more closely follow the Gym naming conventions and hopefully leading to fewer user surprises (I had accidentally created 'JacksCarRental-v0' and it took a while before I realized the different naming convention for this repo).

With the PR, creating the environment becomes:

`env = gym.make('JacksCarRental-v0')`

This naming makes this package consistent will all the builtin Gym environments, where each environment `X-vn` of version `vn` passed to `gym.make` corresponds to a Python `class XEnv`. None of the Gym environments have an `Env` suffix in the names from which they are created.

Small drive-by changes to `__init__.py` are to use f-strings and to explicitly the path to the implementation (this again follows the examples in the Gym: https://github.com/openai/gym/blob/master/gym/envs/__init__.py)